### PR TITLE
add strict mode

### DIFF
--- a/lib/locations.js
+++ b/lib/locations.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const got = require('got')
 const csv = require('tiny-csv')
 

--- a/lib/trips.js
+++ b/lib/trips.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const got = require('got')
 const moment = require('moment-timezone')
 


### PR DESCRIPTION
This fixes [build `#1` of derhuerst/search-meinfernbus-locations](https://travis-ci.org/derhuerst/search-meinfernbus-locations/jobs/154016244).

```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```