### PR TITLE
got -> isomorphic-fetch, fix link in readme

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,8 +1,21 @@
 'use strict'
 
-const got = require('got')
+const fetch = require('isomorphic-fetch')
+const qs = require('querystring')
 
-const request = (route, headers, query) =>
-	got('http://api.meinfernbus.de/mobile/v1/' + route, {json: true, headers, query})
+
+
+const request = (route, headers, query) => {
+	headers = new Headers(headers)
+	query = qs.stringify(query)
+	return fetch('http://api.meinfernbus.de/mobile/v1/'+ route + '?' + query, {headers})
+	.then((res) => {
+		if (res.status === 304) return res
+		return res.json().then((parsed) => {
+			res.body = parsed
+			return res
+		})
+	}, (res) => {throw res})
+}
 
 module.exports = request

--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const got = require('got')
+
+const request = (route, headers, query) =>
+	got('http://api.meinfernbus.de/mobile/v1/' + route, {json: true, headers, query})
+
+module.exports = request

--- a/locations.js
+++ b/locations.js
@@ -1,7 +1,8 @@
 'use strict'
 
-const got = require('got')
 const csv = require('tiny-csv')
+
+const fetch = require('./fetch')
 
 const err = (error) => {throw error}
 const m = (a) => ((a===undefined) ? null : a)
@@ -53,7 +54,7 @@ const request = (parseFunction, opt) => {
 	}
 	if (etag) headers['If-None-Match'] = etag
 
-	return got('http://api.meinfernbus.de/mobile/v1/network.json', {json: true, headers})
+	return fetch('network.json', headers, {})
 		.then((res) => {
 			const newEtag = parseEtag(res.headers.etag)
 			if (newEtag !== etag) {

--- a/locations.js
+++ b/locations.js
@@ -56,16 +56,14 @@ const request = (parseFunction, opt) => {
 
 	return fetch('network.json', headers, {})
 		.then((res) => {
-			const newEtag = parseEtag(res.headers.etag)
+			if (res.statusCode === 304) return data
+			const newEtag = parseEtag(res.headers.get('Etag'))
 			if (newEtag !== etag) {
 				data = parseFunction(res.body)
 				etag = newEtag
 			}
 			return data
-		}, (res) => {
-			if (res.statusCode === 304 && data) return data
-			else throw res
-		})
+		}, err)
 }
 
 const cities = (opt) => request(parseCities, opt)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"repository": "juliuste/meinfernbus",
 	"bugs": "https://github.com/juliuste/meinfernbus/issues",
 	"main": "index.js",
-	"files": ["index.js", "trips.js", "locations.js", "docs/*"],
+	"files": ["index.js", "trips.js", "locations.js", "fetch.js", "docs/*"],
 	"dependencies": {
 		"moment-timezone": "^0.5.5",
 		"got": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"files": ["index.js", "trips.js", "locations.js", "fetch.js", "docs/*"],
 	"dependencies": {
 		"moment-timezone": "^0.5.5",
-		"got": "^6.3.0",
+		"isomorphic-fetch": "^2.2.1",
 		"tiny-csv": "^3.0.0"
 	},
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ const mfb = require('meinfernbus')
 ## Similar Projects
 
 - [search-meinfernbus-locations](https://github.com/derhuerst/search-meinfernbus-locations/) - "Search for Flixbus/MeinFernbus cities & stations."
-- [db-meinfernbus-cities](https://github.com/juliuste/meinfernbus/) – "Get all DB stations located in the same city as the given Meinfernbus location, and vice versa."
+- [db-meinfernbus-cities](https://github.com/juliuste/db-meinfernbus-cities/) – "Get all DB stations located in the same city as the given Meinfernbus location, and vice versa."
 - [db-hafas](https://github.com/derhuerst/db-hafas/) - "JavaScript client for the DB Hafas API."
 - [db-stations](https://github.com/derhuerst/db-stations/) - "A list of DB stations."
 

--- a/trips.js
+++ b/trips.js
@@ -1,7 +1,8 @@
 'use strict'
 
-const got = require('got')
 const moment = require('moment-timezone')
+
+const fetch = require('./fetch')
 
 const err = (error) => {throw error}
 
@@ -71,11 +72,11 @@ const parseTrips = (trips) => {
 
 const trips = (from, to, date, opt) => {
 	opt = Object.assign({}, defaults, opt || {})
-	return got('http://api.meinfernbus.de/mobile/v1/trip/search.json', {json: true, headers: {
+	return fetch('trip/search.json', {
 		'X-API-Authentication': opt.key,
 		'User-Agent': 'FlixBus/3.3 (iPhone; iOS 9.3.4; Scale/2.00)',
 		'X-User-Country': 'de'
-	}, query: {
+	}, {
 		from: +from,
 		to: +to,
 		departure_date: formatInputDate(date),
@@ -86,7 +87,7 @@ const trips = (from, to, date, opt) => {
 		adult: +opt.adults,
 		children: +opt.children,
 		bikes: +opt.bikes
-	}}).then((res) => {return parseTrips(res.body.trips)},err)
+	}).then((res) => {return parseTrips(res.body.trips)},err)
 }
 
 module.exports = trips


### PR DESCRIPTION
**This PR intends to make `meinfernbus` more lightweight when used in the browser.**

I then ran the following with each of the candidate HTTP libraries.

```shell
browserify index.js > bundle.js
uglify-js -mc --screw-ie8 bundle.js > min.js
cat min.js | gzip > min.js.gz
```

lib | bundle | minified | minified + gzipped
---|--------|---------|-------------------
[`got`](https://github.com/sindresorhus/got) | 227k | 93k | 29k
[`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch/issues) + `querystring`| 17k | 8.5k | 3.0k
[`request`](https://github.com/request/request#readme) | 1.8m | 955k | 276k
[`fetch-ponyfill`](https://github.com/qubyte/fetch-ponyfill) + `querystring` | 20k | 8.6k | 3.0k

As you can see, `got` ends up in between `isomorphic-fetch` and `request`, but is still *10 times* heavier than the former. **Because the Meinfernbus API doesn't redirect and automatic retries don't seem to be worth the bloat, I switched to `isomorphic-fetch`.**
